### PR TITLE
Fixed weird grammar edge cases

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,14 @@
 import React, { useState } from 'react'
 import './App.css'
 
+function formatOutput(anInput, aMap){
+	let res = anInput.split(" ");
+	res = res.map(s => {
+		return (s in aMap) ? aMap[s] : s
+	});
+	return res.join(" ")
+}
+
 function App() {
 	const splashState = localStorage.getItem('should-show-splash-page-first')
 		? false
@@ -13,12 +21,21 @@ function App() {
 	const [inputA, setInputA] = useState('')
 	const [inputB, setInputB] = useState('')
 
+	//you  can add more to these as you find strange edge cases
+	const selfReplyMap = {
+		my:"your",
+		your:"their"
+	}
+
+	const copyReplyMap = {
+		my:"their",
+		your:"their"
+	}
+
 	const fetchrandomBoolean = async (e) => {
 		e.preventDefault()
 		setIsLoading(true)
 		let startTime = Date.now()
-		
-
 		try {
 			const response = await fetch(
 				`https://qrng.anu.edu.au/API/jsonI.php?length=1&type=uint8`,
@@ -226,10 +243,10 @@ function App() {
 		if (!options.self) return
 		return (
 			<div id='result'>
-				<h2>You should {options.self.replace("my", "your")}</h2>
+				<h2>You should {formatOutput(options.self, selfReplyMap)}</h2>
 				The world branched in two approximately{' '}
 				{Math.round(delay / 2 / 100) / 10} seconds ago. <br />A version of you
-				has just been informed that they should {options.copy.replace("my", "their")}.
+				has just been informed that they should {formatOutput(options.copy, copyReplyMap)}.
 			</div>
 		)
 	}

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,8 @@ function App() {
 		e.preventDefault()
 		setIsLoading(true)
 		let startTime = Date.now()
+		
+
 		try {
 			const response = await fetch(
 				`https://qrng.anu.edu.au/API/jsonI.php?length=1&type=uint8`,
@@ -224,10 +226,10 @@ function App() {
 		if (!options.self) return
 		return (
 			<div id='result'>
-				<h2>You should {options.self}</h2>
+				<h2>You should {options.self.replace("my", "your")}</h2>
 				The world branched in two approximately{' '}
 				{Math.round(delay / 2 / 100) / 10} seconds ago. <br />A version of you
-				has just been informed that they should {options.copy}.
+				has just been informed that they should {options.copy.replace("my", "their")}.
 			</div>
 		)
 	}

--- a/src/App.js
+++ b/src/App.js
@@ -2,11 +2,9 @@ import React, { useState } from 'react'
 import './App.css'
 
 function formatOutput(anInput, aMap){
-	let res = anInput.split(" ");
-	res = res.map(s => {
+	return anInput.split(" ").map(s => {
 		return (s in aMap) ? aMap[s] : s
-	});
-	return res.join(" ")
+	}).join(" ");
 }
 
 function App() {


### PR DESCRIPTION
before this change, typing in "fix my house" would result in strange output grammar like "you should fix my house" and "A version of you has just been informed that they should fix my house" when it should be "you should fix _your_ house" and "A version of you has just been informed that they should fix _their_ house."

this fixes that issue and can easily be modified by adding more grammar rules in the future.

